### PR TITLE
Add time checks for parameters

### DIFF
--- a/osc_counter/contact.py
+++ b/osc_counter/contact.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+class Contact:
+
+    def __init__(self, name):
+        self.name = name
+        self.current_count = 1
+        self.last_count = 1
+        self.last_activated = datetime.now()
+
+    def serializable_data(self) -> dict:
+        data = {
+            "current_count" : self.current_count,
+            "last_count" : self.last_count,
+            "last_activated" : self.last_activated.timestamp()
+        }
+  
+        return data

--- a/osc_counter/filemanager.py
+++ b/osc_counter/filemanager.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from contact import Contact
 import json
 
 class FileManager:
@@ -7,9 +8,8 @@ class FileManager:
     def add_contact(self, contact_name: str) -> None:
         tracker = self.get_tracker()
         tracker[contact_name]['current_count'] = tracker[contact_name]['current_count']+1
-
-        with open("tracker.json", "w") as jsonFile:
-            json.dump(tracker, jsonFile)
+        tracker[contact_name]['last_activated'] = datetime.now().timestamp()
+        self.dump_tracker(tracker)
 
     # Sets the last count to the current count so that it can be updated in the OSC Server
     # The value in last_count is sent as a message to the OSC Server in messenger.py:format_message()
@@ -23,8 +23,7 @@ class FileManager:
                 print(f"Gained {current_count - last_count} {contact_name.capitalize()}!")
                 tracker[contact_name]['last_count'] = current_count
 
-        with open("tracker.json", "w") as jsonFile:
-            json.dump(tracker, jsonFile)
+        self.dump_tracker(tracker)
 
     # The list of keys in the tracker.json file has to be updated while running 
     # because we can't know beforehand what parameters exist for the avatar
@@ -33,16 +32,18 @@ class FileManager:
 
     def inject_new_contact(self, contact_name: str) -> None:
         tracker = self.get_tracker()
-
-        tracker[contact_name] = {'current_count' : 1,'last_count' : 1}
-        with open("tracker.json", "w") as jsonFile:
-            json.dump(tracker, jsonFile)
+        contact = Contact(contact_name)
+        tracker[contact.name] = contact.serializable_data()
+        self.dump_tracker(tracker)
 
     def get_tracker(self) -> dict:
         with open("tracker.json", "r") as jsonFile:
             tracker = json.load(jsonFile)
-
         return tracker
+
+    def dump_tracker(self, tracker) -> None:
+        with open("tracker.json", "w") as jsonFile:
+            json.dump(tracker, jsonFile)
 
 
 

--- a/osc_counter/messenger.py
+++ b/osc_counter/messenger.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 
 class Messenger:
 
@@ -9,8 +10,9 @@ class Messenger:
 
         message =  ""
         for contact_name in tracker.keys():
-            n_ctx = self.format_number(tracker[contact_name]['current_count'])
-            message += f"{contact_name.capitalize()}: {n_ctx}, "
+            if(self.can_it_populate(tracker[contact_name]['last_activated'])):
+                n_ctx = self.format_number(tracker[contact_name]['current_count'])
+                message += f"{contact_name.capitalize()}: {n_ctx}, "
 
         if len(tracker.keys()) >= 1:
             message = message[:-2]
@@ -19,6 +21,10 @@ class Messenger:
 
     def format_number(self, number: int) -> str:
         return "{:,}".format(number)
+
+    def can_it_populate(self, last_activated) -> bool:
+        delta =  datetime.now().timestamp() - last_activated
+        return delta <= 60
 
     def has_new_content(self, tracker: dict) -> bool:
 

--- a/tracker.json
+++ b/tracker.json
@@ -1,1 +1,1 @@
-{ "Headpats": { "current_count": 0, "last_count": 0 } }
+{}


### PR DESCRIPTION
**What I Did:** Added a time check to see if which parameters had been active in the last minute. Only Parameters that have been recently active will populate in VRC's chatbox. 

This was necessary so that people can have many parameters on one avatar without it sending all the counters to the chatbox, even when they were not relevant to what was happening at the time. 

For example lets say I am tracking headpats and nose-boops. If I receive headpat and than 40 seconds later I receive a nose-boop than both those will populate in the chatbox. However if I receive a headpat and than 120 seconds later receive a nose -boop than only the nose-boop will populate since headpats have not been given in over 60 seconds.