### PR TITLE
Contact frequency setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VRChat Headpat+ Counter
+# Dynamic OSC Contact Counter for VRChat
 
 ### <b>[How To Setup](#How-To-Setup) | [Customize Your Parameters](#Customize-Your-Parameters) | [Troubleshooting](#Troubleshooting)
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,3 @@
 {
-  "TriggerDelay": 0,
   "ParamPersistance": 60
 }

--- a/osc_counter/contact.py
+++ b/osc_counter/contact.py
@@ -7,12 +7,14 @@ class Contact:
         self.current_count = 1
         self.last_count = 1
         self.last_activated = datetime.now()
+        self.frequency_limit = 0
 
     def serializable_data(self) -> dict:
         data = {
             "current_count" : self.current_count,
             "last_count" : self.last_count,
-            "last_activated" : self.last_activated.timestamp()
+            "last_activated" : self.last_activated.timestamp(),
+            "frequency_limit" : self.frequency_limit
         }
   
         return data

--- a/osc_counter/oscserver.py
+++ b/osc_counter/oscserver.py
@@ -41,7 +41,7 @@ class OSCServer():
                 self.filemanager.inject_new_contact(contact_name)
 
     def _process_osc(self) -> None:
-        print("[OSCThread] Launching OSC server thread!")
+        print("Program Launched! Awaiting interactions:")
         self.server.serve_forever()
 
     def message(self, tracker: dict) -> None:

--- a/osc_counter/setup.py
+++ b/osc_counter/setup.py
@@ -3,11 +3,14 @@ from oscserver import OSCServer
 from timechecker import TimeChecker
 from filemanager import FileManager
 from messenger import Messenger
+from updater import Updater
 
 def main():
     messenger_timer = TimeChecker(1.5)
     messenger = Messenger(messenger_timer)
     filemanager = FileManager()
+    updater = Updater()
+    updater.auto_update_tracker()
     osc = OSCServer(filemanager, messenger)
     osc.launch()
 

--- a/osc_counter/updater.py
+++ b/osc_counter/updater.py
@@ -1,0 +1,25 @@
+from contact import Contact
+from filemanager  import FileManager
+
+class Updater():
+
+    def __init__(self) -> None:
+        self.file_manager = FileManager()
+
+    def auto_update_tracker(self) -> None:
+        tracker = self.file_manager.get_tracker()
+        if(len(tracker) > 0):
+            self.execute_checker(tracker)
+        print("tracker.json is up to date.")
+
+    # checks for each property in the first key from tracker.json
+    # adds any missing properties with the default values those properties would instantiate with
+    def execute_checker(self, tracker: dict) -> None:
+        contact = Contact('UPDATER')
+        serialized_contact = contact.serializable_data()
+        for prop in serialized_contact:
+            if not prop in tracker[next(iter(tracker))].keys():
+                print(f"Adding {prop} to each contact.")
+                for contact_name in tracker:
+                    tracker[contact_name][prop] = serialized_contact[prop] 
+            self.file_manager.dump_tracker(tracker)

--- a/osc_counter/usersettings.py
+++ b/osc_counter/usersettings.py
@@ -5,7 +5,6 @@ class UserSettings:
 
     def __init__(self) -> None:
         self.config: dict = self.get_config()
-        self.trigger_delay: int = self.config['TriggerDelay']
         self.param_persistance: int = self.force_minimum(self.config['ParamPersistance'], 1)
 
     def force_minimum(self, num_val: int, minimum: int) -> int:
@@ -14,7 +13,7 @@ class UserSettings:
     def is_past_delay(self, contact: dict) -> bool:
         current_time = datetime.now().timestamp()
         delta = current_time - contact['last_activated']
-        return True if delta > self.trigger_delay else False
+        return True if delta > contact['frequency_limit'] else False
          
 
     def get_config(self) -> dict:


### PR DESCRIPTION
What I did:
Made it so that each contact can have there own set limits to how quickly they can be triggered again as opposed to it being a global setting. In addition to this I have made it so that old `tracker.json` files will automatically update with newly added settings to prevent errors when updating to later builds. 

Files Changed: 
- `updater.py` added an auto updater to place in any missing settings for contacts in `tracker.json`
- `usersettings.py` remmoved trigger_delay. This is now replaced with `frequency_limit` set on each contact in `tracker.json`